### PR TITLE
Add a forward slash before stylesheet/favicon URLs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,14 +16,14 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/lanyon.css">
+  <link rel="stylesheet" href="/{{ site.baseurl }}public/css/poole.css">
+  <link rel="stylesheet" href="/{{ site.baseurl }}public/css/syntax.css">
+  <link rel="stylesheet" href="/{{ site.baseurl }}public/css/lanyon.css">
   <!-- <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400"> -->
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
 
   <!-- Icons -->
-  <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
+  <link rel="shortcut icon" href="/{{ site.baseurl }}public/favicon.ico">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">


### PR DESCRIPTION
As noted in #12, this pull request adds a `/` before all stylesheet URLs. There is also a favicon URL that was affected so I have corrected that as well.

I am unable to verify if these changes have worked (not sure what the build tool being used here is!) but I am reasonably confident this will work (editing the URLs via inspect element fixed the issue, at least).